### PR TITLE
feat(ci/cd): GitHub Actions 배포 워크플로 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy To EC2
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH(원격접속)로 EC2에 접속하여 자동 배포하기
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          APPLICATION_YML: ${{ secrets.APPLICATION_YML }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: APPLICATION_YML
+          script: |
+            # 해당 디렉토리로 이동
+            cd /home/ubuntu/backend
+            
+            # 이전 프로세스 종료
+            sudo fuser -k -n tcp 8080 || true
+            
+            # 존재하는 .yml 삭제
+            rm -rf src/main/resources/application.yml
+            
+            # 코드 업데이트 및 빌드
+            git pull origin main
+            echo "$APPLICATION_YML" > src/main/resources/application.yml
+            chmod +x ./gradlew 
+            ./gradlew clean build
+            
+            # 애플리케이션 실행
+            nohup java -jar build/libs/*SNAPSHOT.jar > ./output.log 2>&1 &
+            
+            # 배포 확인
+            sleep 10
+            if pgrep -f "*SNAPSHOT.jar" > /dev/null; then
+              echo "Deployment successful"
+            
+              # 로그 확인을 위한 마지막 몇 줄 출력
+              tail -n 50 ./output.log
+            else
+              echo "Deployment failed"
+              cat ./output.log
+              exit 1
+            fi


### PR DESCRIPTION
EC2에 자동 배포를 위한 GitHub Actions 워크플로 추가:
- 메인 브랜치 푸시에서 배포 트리거 구성
- EC2 인스턴스에 대한 SSH 연결 설정
- 애플리케이션 빌드 및 배포 프로세스 구현
- 배포 상태 확인 추가
- 환경 변수 및 비밀 관리 구성

기술적 변경 사항:
- deploy.yml 워크플로 구성 추가
- 애플리케이션 재시작을 위한 프로세스 관리 설정
- 배포 검증을 위한 로그 모니터링 구현
- GitHub 비밀 번호를 통한 application.yml 처리 구성